### PR TITLE
Remove caching of ratio to allow change of image src

### DIFF
--- a/jquery.object-fit.js
+++ b/jquery.object-fit.js
@@ -72,7 +72,7 @@
 		}
 
 		var $this = $(elem),
-				ratio = $this.data('ratio'),
+				ratio,
 				parent = findParentRatio($this), // The parent element may not have any width or height, so find one that does
 				pic_real_width,
 				pic_real_height;
@@ -82,11 +82,7 @@
 				pic_real_width = this.width;   // Note: $(this).width() will not
 				pic_real_height = this.height; // work for in memory images.
 
-				// set the ratio of the object. we assume, that the ratio of the object never changes.
-				if (ratio === undefined) {
-					ratio = pic_real_width / pic_real_height;
-					$this.data('ratio', ratio);
-				}
+				ratio = pic_real_width / pic_real_height;
 
 				// Set the width/height
 				if (type === 'contain') {


### PR DESCRIPTION
I just ran into an issue with using this plugin in an application where the src attribute is switched out dynamically and I wanted to re-object-fit 'contain' the same image tag. I worked around it by `$('img').removeData('ratio')` but when I started looking through this source, I had a hard time understanding the need for caching the ratio.

All of the information to perform the calculation is available at the time of checking the cache and it's just a simple division away. Please let me know your thoughts. 

BTW. Thanks so much for all of your work on this plugin!
